### PR TITLE
Just an update to README.md, to reflect a change GitHub seems to have made to the location of raw files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Install
 `repl` is easily installed as a standalone script:
 
     export REPL_BIN=~/bin/repl
-    curl -s https://github.com/defunkt/repl/raw/latest/bin/repl > $REPL_BIN
+    curl -s https://raw.github.com/defunkt/repl/latest/bin/repl > $REPL_BIN
     chmod 755 $REPL_BIN
 
 Change `$REPL_BIN` to your desired location and have at! (Just make


### PR DESCRIPTION
GitHub has clearly changed the address to access raw files from. 

This meant the instructions to install c-repl as a standalone script didn't work.

I updated line 95 of README.md to reflect the change, so it points to the correct script location. 

It's a shame curl can't follow the redirect.
