### PR TITLE
Improves custom prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,15 @@ Configuration
 The following environment variables affect `repl`'s behavior:
 
 `REPL_PROMPT`:
-    the prompt to display before each line of input. defaults to >>
+    The prompt to display before each line of input. defaults to >>
+
+`REPL_PROMPT_SIMPLE`:
+    By default `REPL_PROMPT` is prefixed with the command being run,
+    e.g. 'gem>>'. Set `REPL_PROMPT_SIMPLE` to '1' to override this
+    behavior and display only `REPL_PROMPT`, e.g. '>>'
 
 `REPL_COMPLETION_DIR`:
-    directory in which completion files are kept
+    Directory in which completion files are kept
 
 
 Contributing

--- a/bin/repl
+++ b/bin/repl
@@ -86,8 +86,12 @@ if debug
   puts command.inspect
 end
 
+prompt = ""
+prompt += ARGV[0] unless ENV['REPL_PROMPT_SIMPLE']
+prompt += ENV['REPL_PROMPT'] || '>>'
+
 loop do
-  print ENV['REPL_PROMPT'] || "#{ARGV[0]}>> "
+  print prompt
 
   begin
     line = $stdin.gets.chomp


### PR DESCRIPTION
Fixes #15 in defunkt/repl

Checks the environment variable `REPL_PROMPT_SIMPLE` to determine
whether to include `#{ARGV[0]}` prefix as a part of the prompt,
regardless of whether a custom `REPL_PROMPT` has been specified
