### PR TITLE
Fixed bug report url

### DIFF
--- a/bin/repl
+++ b/bin/repl
@@ -27,7 +27,7 @@ Options:
   --man     Display the man page
 
 Bug reports, suggestions, updates:
-http://http://github.com/defunkt/repl/issues
+http://github.com/defunkt/repl/issues
 help
   exit
 end


### PR DESCRIPTION
The url listed for bug reports began http://http:// and has been fixed herein
