### PR TITLE
Exception added for running shell commands without exit:

### DIFF
--- a/bin/repl
+++ b/bin/repl
@@ -98,7 +98,12 @@ loop do
   if from_stdin
     run = "echo \"%s\" | #{command}" % [ line, nil ]
   else
-    run = "#{command} %s" % [ line, nil ]
+    if line =~ /^!/
+      line[0] = ''
+      run = "#{line} 2>&1"
+    else
+      run = "#{command} %s" % [ line, nil ]
+    end
   end
   puts "$ #{run}" if debug
   system run


### PR DESCRIPTION
if string begins with '!' it runs in shell.

(Sorry, if you find it's dirty. I'm just missing this feature a lot.) 